### PR TITLE
Allow arbitrary whitespace in grammar specification.

### DIFF
--- a/parsing/automaton.py
+++ b/parsing/automaton.py
@@ -9,7 +9,8 @@ import sys
 
 from parsing.errors import SpecError
 from parsing.interfaces import is_spec_source
-from parsing.module_spec import ModuleSpecSource
+from parsing import introspection
+from parsing import module_spec
 from parsing.grammar import (Precedence, Production, TokenSpec, NontermSpec,
                              SymbolSpec, EndOfInput, eoi, Epsilon, epsilon,
                              NontermStart, Action, ShiftAction, ReduceAction)
@@ -568,7 +569,7 @@ the Parser class for parsing.
         if isinstance(adapter, types.ModuleType) or (
                 isinstance(adapter, list) and
                 isinstance(adapter[0], types.ModuleType)):
-            adapter = ModuleSpecSource(adapter)
+            adapter = module_spec.ModuleSpecSource(adapter)
         elif not is_spec_source(adapter):
             raise ValueError("%r should be a specification source" %
                              (adapter, ))
@@ -723,7 +724,7 @@ the Parser class for parsing.
                 v = d[k]
                 if (isinstance(v, types.FunctionType) and
                         isinstance(v.__doc__, str)):
-                    dirtoks = v.__doc__.split(" ")
+                    dirtoks = introspection.parse_docstring(v.__doc__)
                     if dirtoks[0] == "%reduce":
                         rhs = []
                         rhs_terms = []

--- a/parsing/grammar.py
+++ b/parsing/grammar.py
@@ -27,6 +27,7 @@ import re
 import sys
 from parsing.ast import Token, Nonterm
 from parsing.errors import SpecError
+from parsing import introspection
 
 
 class Precedence(object):
@@ -185,7 +186,7 @@ class NontermSpec(SymbolSpec):
         if nt_subclass.__doc__ is None:
             dirtoks = ['%nonterm', name]
         else:
-            dirtoks = nt_subclass.__doc__.strip().split()
+            dirtoks = introspection.parse_docstring(nt_subclass.__doc__)
         is_start = (dirtoks[0] == '%start')
         # if dirtoks[0] in SHORTHAND:
         #    dirtoks = ['%nonterm', name]

--- a/parsing/introspection.py
+++ b/parsing/introspection.py
@@ -1,0 +1,5 @@
+import re
+
+
+def parse_docstring(s):
+    return list(filter(None, re.split(r'\s+', s.replace('\n', ' '))))

--- a/parsing/module_spec.py
+++ b/parsing/module_spec.py
@@ -5,6 +5,7 @@ classes in a module.
 import types
 from parsing.grammar import Precedence, TokenSpec, NontermSpec, SpecError
 from parsing.ast import Token, Nonterm
+from parsing import introspection
 
 
 class ModuleSpecSource(object):
@@ -22,7 +23,7 @@ class ModuleSpecSource(object):
         for module in self.modules:
             for k, v in module.__dict__.items():
                 if isinstance(v, type) and isinstance(v.__doc__, str):
-                    dirtoks = v.__doc__.split(" ")
+                    dirtoks = introspection.parse_docstring(v.__doc__)
                     items.append((module, k, v, dirtoks))
         self.named_objs = items
         self._cache_precedences = None

--- a/parsing/tests/specs/a.py
+++ b/parsing/tests/specs/a.py
@@ -6,7 +6,10 @@ class P1(parsing.Precedence):
 
 
 class p2(parsing.Precedence):
-    "%left >p1"
+    """
+        %left
+            >p1
+    """
 
 
 # Tokens.
@@ -56,10 +59,15 @@ class T(parsing.Nonterm):
 
 
 class NontermF(parsing.Nonterm):
-    "%nonterm F [p2]"
+    """
+    %nonterm
+    F    [p2]
+    """
 
     def reduceA(self, lparen, E, rparen):
-        "%reduce lparen E rparen"
+        """%reduce
+        lparen E rparen
+        """
         self.val = '(%s)' % (E.val, )
 
     def reduceB(self, id):


### PR DESCRIPTION
All whitespace is now correctly stripped from grammar specifications.